### PR TITLE
Fix/persistence issue

### DIFF
--- a/src/internal/connected-wallets.ts
+++ b/src/internal/connected-wallets.ts
@@ -23,6 +23,9 @@ export function setConnectedWallet(key: string, handler: ExtendedWalletHandler):
 
 export function deleteConnectedWallet(key: string): void {
   const existing = connectedWallets.get(key);
+  if (!existing) {
+    return;
+  }
   cleanupHandler(existing);
   connectedWallets.delete(key);
   if (defaults.persistence.enabled) {
@@ -31,6 +34,9 @@ export function deleteConnectedWallet(key: string): void {
 }
 
 export function clearConnectedWallets(): void {
+  if (connectedWallets.size === 0) {
+    return;
+  }
   for (const handler of connectedWallets.values()) {
     cleanupHandler(handler);
   }

--- a/src/lib/react/hooks/use-wallet.hook.ts
+++ b/src/lib/react/hooks/use-wallet.hook.ts
@@ -48,9 +48,10 @@ export function useWallet({
   initialState,
   onUpdateError,
 }: UseWalletOpts = {}): UseWalletReturnType {
-  const [isConnectingTo, setConnectingTo] = useState<string | undefined>(
-    initialState?.isConnectingTo ?? getPersistedValue("connectedWallet"),
-  );
+  const initialIsConnectingTo = useMemo(() => {
+    return initialState?.isConnectingTo ?? getPersistedValue("connectedWallet");
+  }, [initialState?.isConnectingTo]);
+  const [isConnectingTo, setConnectingTo] = useState<string | undefined>(initialIsConnectingTo);
   const [wallet, setWallet] = useState<Wallet>();
 
   const disconnectWallet = useCallback(() => {
@@ -179,11 +180,10 @@ export function useWallet({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Should only try to persist connection on first mount
   useEffect(() => {
-    const persistedWallet = getPersistedValue("connectedWallet");
-    if (persistedWallet) {
-      connectWallet(persistedWallet);
+    if (initialIsConnectingTo) {
+      connectWallet(initialIsConnectingTo);
     }
-  }, []);
+  }, [initialIsConnectingTo]);
 
   return { wallet: state, connectWallet, connectWalletAsync, disconnectWallet };
 }


### PR DESCRIPTION
### Issue
The cookie was being deleted on every reload which was causing race conditions that led to persisted wallet being deleted.

### Fix
I added checks to prevent the wallet deletion flow to run when there is no connected wallet.

### Other issue
I fixed another issue where useWallet didn't reliably use its initialState prop when persisting connection.